### PR TITLE
remove mercurial import from cinnabar/githg.py

### DIFF
--- a/cinnabar/githg.py
+++ b/cinnabar/githg.py
@@ -9,6 +9,7 @@ from itertools import (
     izip,
 )
 from hashlib import sha1
+import difflib
 import os
 import re
 import urllib
@@ -32,7 +33,6 @@ from .git import (
 from .helper import GitHgHelper
 from .util import progress_iter
 from .dag import gitdag
-from mercurial import mdiff
 from distutils.dir_util import mkpath
 
 import time
@@ -95,6 +95,61 @@ def get_hg_author(author):
 revchunk_log = logging.getLogger('revchunks')
 
 
+def _normalizeblocks(a, b, blocks):
+    prev = None
+    r = []
+    for curr in blocks:
+        if prev is None:
+            prev = curr
+            continue
+        shift = 0
+
+        a1, b1, l1 = prev
+        a1end = a1 + l1
+        b1end = b1 + l1
+
+        a2, b2, l2 = curr
+        a2end = a2 + l2
+        b2end = b2 + l2
+        if a1end == a2:
+            while (a1end + shift < a2end and
+                   a[a1end + shift] == b[b1end + shift]):
+                shift += 1
+        elif b1end == b2:
+            while (b1end + shift < b2end and
+                   a[a1end + shift] == b[b1end + shift]):
+                shift += 1
+        r.append((a1, b1, l1 + shift))
+        prev = a2 + shift, b2 + shift, l2 - shift
+    r.append(prev)
+    return r
+
+def bdiff(a, b):
+    a = str(a).splitlines(True)
+    b = str(b).splitlines(True)
+
+    if not a:
+        s = "".join(b)
+        return s and (struct.pack(">lll", 0, 0, len(s)) + s)
+
+    bin = []
+    p = [0]
+    for i in a: p.append(p[-1] + len(i))
+
+    d = difflib.SequenceMatcher(None, a, b).get_matching_blocks()
+    d = _normalizeblocks(a, b, d)
+    la = 0
+    lb = 0
+    for am, bm, size in d:
+        s = "".join(b[lb:bm])
+        if am > la or s:
+            bin.append(struct.pack(">lll", p[la], p[am], len(s)) + s)
+        la = am + size
+        lb = bm + size
+
+    return "".join(bin)
+
+
 class RevChunk(object):
     def __init__(self, chunk_data):
         self.node, self.parent1, self.parent2, self.changeset = (
@@ -138,7 +193,7 @@ class RevChunk(object):
         ).hexdigest()
 
     def diff(self, other):
-        return mdiff.textdiff(other.data if other else '', self.data)
+        return bdiff(other.data if other else '', self.data)
 
     def serialize(self, other):
         header = struct.pack(


### PR DESCRIPTION
The only thing githg.py needs the mercurial libraries for is generating
diffs of the format used in bundles.  For now we can just copy the two
functions in mercurial/pure/bdiff.py that are necessary to generate this
format of diff.  This may be somewhat slower than using the C
implementation of bdiff, however it should make it easier to switch to
generating bundles entirely in C.

This is only very lightly tested at this point, but presumably this code is tested when in the mercurial repo, and the integration is very straight forward.  That said advice on testing would be nice.