### PR TITLE
Give 'git diff-tree' the '-C' option twice to detect exact copying.

### DIFF
--- a/cinnabar/git.py
+++ b/cinnabar/git.py
@@ -457,7 +457,7 @@ class Git(object):
             if recursive:
                 args.insert(0, '-r')
             if detect_copy:
-                args[:0] = ['-C100%']
+                args[:0] = ['-C', '-C']
             self._diff_tree[key] = GitProcess('diff-tree', *args,
                                               stdin=subprocess.PIPE)
         diff_tree = self._diff_tree[key]


### PR DESCRIPTION
Looks like #7 doesn't work because 'git-diff-tree' (git version 2.9.0) wouldn't find exact copy with only one '-C' option:

``` shell
$ git log --stat --pretty=oneline
44c1953e64ee79c1a25d5096250816a3973dd149 copy
 target | 1 +
 1 file changed, 1 insertion(+)
7dc80b605277bf4c889a99a968a7e88e40a6beb7 create source
 source | 1 +
 1 file changed, 1 insertion(+)
```

``` shell
$ git diff-tree -r -C100% --name-status HEAD~ HEAD
A   target
```

Adding one more '-C'  seems fix it:

``` shell
$ git diff-tree -r -C -C --name-status HEAD~ HEAD
C100    source  target
```
