### PR TITLE
move and ignore git-cinnabar-helper, so it doesn't appear untracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 CI-data
 CI-data.mk
+git-cinnabar-helper

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ include git-core/config.mak.uname
 git-cinnabar-helper$X: FORCE
 
 helper: git-cinnabar-helper$X
-	cp git-core/$^ $^
+	mv git-core/$^ $^
 
 else
 


### PR DESCRIPTION
Making the helper leaves the workdir modified in two ways: the submodule has "untracked content", and the supermodule has an "untracked file":

```
> git status
…
Changes not staged for commit:
  …
  modified:   git-core (untracked content)

Untracked files:
  …
  git-cinnabar-helper
```

This branch moves git-cinnabar-helper from the submodule to the supermodule (instead of copying it) and adds `git-cinnabar-helper` to the supermodule's .gitignore file to resolve these issues.
