### PR TITLE
document building without gettext, specifying openssl location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ PYTHON_LIBS := \
 	cinnabar/hg/changegroup.py \
 	cinnabar/util.py
 
+NO_GETTEXT ?= 1
+NO_OPENSSL ?= 1
+
 ifneq (,$(wildcard $(CURDIR)/git-core/Makefile))
 all:
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ have installed it using homebrew) you need to pass
 `PYTHON_PATH` environment variable to your Python installation path when using
 make to build this tool.
 
+If you don't have gettext, then you'll need to disable localization support
+in git when building the helper:
+
+  ```
+  $ NO_GETTEXT=1 make helper
+  ```
+
+If you installed OpenSSL using homebrew on macOS, then you may need to specify
+the locations of its headers and libraries:
+
+  ```
+  $ make helper CFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib"
+  ```
+
 Usage:
 ------
 

--- a/README.md
+++ b/README.md
@@ -56,20 +56,6 @@ have installed it using homebrew) you need to pass
 `PYTHON_PATH` environment variable to your Python installation path when using
 make to build this tool.
 
-If you don't have gettext, then you'll need to disable localization support
-in git when building the helper:
-
-  ```
-  $ NO_GETTEXT=1 make helper
-  ```
-
-If you installed OpenSSL using homebrew on macOS, then you may need to specify
-the locations of its headers and libraries:
-
-  ```
-  $ make helper CFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib"
-  ```
-
 Usage:
 ------
 


### PR DESCRIPTION
These two additions to the README document fixes for issues I ran into while building the helper. They should help others get it built more quickly.
