### PR TITLE
Intercept exceptions and provide a human readable message for the users

### DIFF
--- a/cinnabar/cmd/data.py
+++ b/cinnabar/cmd/data.py
@@ -1,9 +1,7 @@
 import sys
 from cinnabar.cmd.util import CLI
-from cinnabar.githg import (
-    GitHgStore,
-    UpgradeException,
-)
+from cinnabar.exceptions import UpgradeAbort
+from cinnabar.githg import GitHgStore
 
 
 @CLI.subcommand
@@ -17,7 +15,7 @@ def data(args):
 
     try:
         store = GitHgStore()
-    except UpgradeException as e:
+    except UpgradeAbort as e:
         print >>sys.stderr, e.message
         return 1
     if args.changeset and args.manifest:

--- a/cinnabar/cmd/fsck.py
+++ b/cinnabar/cmd/fsck.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from cinnabar.cmd.util import CLI
+from cinnabar.exceptions import UpgradeAbort
 from cinnabar.githg import (
     Changeset,
     ChangesetPatcher,
@@ -8,7 +9,6 @@ from cinnabar.githg import (
     GitCommit,
     GitHgStore,
     HG_EMPTY_FILE,
-    UpgradeException,
 )
 from cinnabar.dag import gitdag
 from cinnabar.git import (
@@ -54,7 +54,7 @@ def fsck(args):
 
     try:
         store = GitHgStore()
-    except UpgradeException as e:
+    except UpgradeAbort as e:
         print >>sys.stderr, e.message
         return 1
 

--- a/cinnabar/cmd/upgrade.py
+++ b/cinnabar/cmd/upgrade.py
@@ -1,8 +1,6 @@
 from cinnabar.cmd.util import CLI
-from cinnabar.githg import (
-    GitHgStore,
-    UpgradeException,
-)
+from cinnabar.exceptions import UpgradeAbort
+from cinnabar.githg import GitHgStore
 from cinnabar.helper import GitHgHelper
 
 
@@ -19,7 +17,7 @@ def upgrade(args):
         store = GitHgStore()
         print 'No metadata to upgrade'
         return 2
-    except UpgradeException:
+    except UpgradeAbort:
         store = UpgradeGitHgStore()
 
     if not GitHgHelper.upgrade():

--- a/cinnabar/exceptions.py
+++ b/cinnabar/exceptions.py
@@ -1,0 +1,38 @@
+class Abort(Exception):
+    """Raised if a command needs to print an error and exit."""
+
+
+class NoHelperAbort(Abort):
+    """No helper has been found."""
+
+
+class HelperClosedError(RuntimeError):
+    """Running a query with a closed helper."""
+
+
+class NothingToGraftException(Exception):
+    """Not found any tree to graft."""
+
+
+class AmbiguousGraftAbort(Abort):
+    """Cannot graft the changeset."""
+
+
+class UpgradeAbort(Abort):
+    """Metadata needs an upgrade."""
+    def __init__(self, message=None):
+        super(UpgradeAbort, self).__init__(
+            message or
+            'Git-cinnabar metadata needs upgrade. '
+            'Please run `git cinnabar upgrade`.'
+        )
+
+
+class OldUpgradeAbort(UpgradeAbort):
+    """Metadata needs a consistency check."""
+    def __init__(self):
+        super(OldUpgradeAbort, self).__init__(
+            'Metadata from git-cinnabar versions older than 0.3.0 is not '
+            'supported.\n'
+            'Please run `git cinnabar fsck` with version 0.3.x first.'
+        )

--- a/cinnabar/hg/repo.py
+++ b/cinnabar/hg/repo.py
@@ -3,8 +3,8 @@ import os
 import sys
 import urllib
 import urllib2
+from cinnabar.exceptions import NothingToGraftException
 from cinnabar.githg import (
-    NothingToGraftException,
     Changeset,
     ManifestInfo,
 )

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -6,10 +6,8 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__)))
 sys.path.append(os.path.join(os.path.dirname(__file__), 'pythonlib'))
 
-from cinnabar.githg import (
-    UpgradeException,
-    GitHgStore,
-)
+from cinnabar.exceptions import UpgradeAbort
+from cinnabar.githg import GitHgStore
 from cinnabar.hg.repo import Remote
 import logging
 from cinnabar.remote_helper import (
@@ -30,7 +28,7 @@ def main(args):
 
     try:
         store = GitHgStore()
-    except UpgradeException as e:
+    except UpgradeAbort as e:
         logging.error(e.message)
         return 1
 


### PR DESCRIPTION
Exceptions are intercepted in the `cinnabar.util.run` method.
If an exception is raised with a message, it is printed out.

A "traceback" check is introduced to provide an option to see the
traceback.

A new module `cinnabar/exceptions.py` is added to define all specific
exceptions.

`Abort` is defined as a base exception for normal command aborts.

`HelperClosed` is now a RuntimeError.