### PR TITLE
Add the Makefile target that also copies the helper in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Setup:
   Alternatively, you can build it:
 
   ```
-  $ make
+  $ make helper
   ```
 
   If you want to build git along the helper, you can run `make git`.


### PR DESCRIPTION
Simply running `make` only builds the helper but doesn't copy it in the parent directory. `make helper` does and is what should be in the README.