### PR TITLE
Allow use of multiple remote ref styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ branches and bookmarks. Mercurial branches are permanent markers on each
 changeset that belongs to them, and bookmarks are similar to git branches.
 
 You may choose how to interact with those with the `cinnabar.refs`
-configuration. The following values are supported:
+configuration. The following values are supported, either individually or
+combined in a comma-separated list:
 
 - `bookmarks`: in this mode, the mercurial repository's bookmarks are exposed
   as `refs/heads/$bookmark`. Practically speaking, this means the mercurial
@@ -97,12 +98,28 @@ configuration. The following values are supported:
   `refs/heads/$branch/$head`, where `$branch` is the mercurial branch name
   and `$head` is the full changeset sha1 of that head.
 
-- `all` (default): in this mode:
-  - bookmarks are exposed as `refs/heads/bookmarks/$bookmark`,
-  - branch heads are exposed as `refs/heads/branches/$branch/$head` (where
-    `$head` is the full changeset sha1 of the head),
-  - except the branch tip, which is exposed as
-    `refs/heads/branches/$branch/tip`.
+When these values are used in combinations, the branch mappings are varied
+accordingly to make the type of each remote ref explicit and to avoid name
+collisions.
+
+- When combining `bookmarks` and `heads`, bookmarks are exposed as
+  `refs/heads/bookmarks/$bookmark` and branch heads are exposed as
+  `refs/heads/branches/$branch/$head` (where `$head` is the full changeset
+  sha1 of the head).
+
+- When combining `bookmarks` and `tips`, bookmarks are exposed as
+  `refs/heads/bookmarks/$bookmark` and branch tips are exposed as
+  `refs/heads/branches/$branch`. Any other heads of the same branch are not
+  exposed.
+
+- When combining all of `bookmarks`, `heads`, and `tips`, bookmarks are
+  exposed as `refs/heads/bookmarks/$bookmark`, branch heads are exposed as
+  `refs/heads/branches/$branch/$head` (where `$head` is the full changeset
+  sha1 of the head), except for the branch tips, which are exposed as
+  `refs/heads/branches/$branch/tip`.
+
+The shorthand `all` (also the default), is the combination of `bookmarks`,
+`heads`, and `tips`.
 
 The refs style can also be configured per remote with the
 `remote.$remote.cinnabar-refs` configuration. It is also possible to use

--- a/cinnabar/remote_helper.py
+++ b/cinnabar/remote_helper.py
@@ -25,6 +25,7 @@ from cinnabar.git import (
     NULL_NODE_ID,
 )
 from cinnabar.util import (
+    ConfigSetFunc,
     IOLogger,
     strip_suffix,
     VersionedDict,
@@ -268,51 +269,45 @@ class GitRemoteHelper(BaseRemoteHelper):
                     self._store, new_branchmap, list(new_heads))
 
         refs_style = None
+        refs_styles = ('bookmarks', 'heads', 'tips')
         if not fetch and branchmap.heads():
-            refs_styles = [
-                None,
-                '',
-                'all',
-                'bookmarks',
-                'heads',
-                'tips',
-            ]
-
-            refs_configs = ['cinnabar.refs']
+            refs_config = 'cinnabar.refs'
             if arg == 'for-push':
-                refs_configs.insert(0, 'cinnabar.pushrefs')
+                if Git.config('cinnabar.pushrefs', remote=self._remote.name):
+                    refs_config = 'cinnabar.pushrefs'
 
-            for refs_config in refs_configs:
-                refs_style = Git.config(refs_config, remote=self._remote.name,
-                                        values=refs_styles)
-                if refs_style:
-                    break
+            refs_style = ConfigSetFunc(refs_config, refs_styles,
+                                       remote=self._remote.name, default='all')
 
-        refs_style = refs_style or 'all'
+        refs_style = refs_style or (lambda x: True)
         self._refs_style = refs_style
 
         refs = {}
-        if refs_style in ('all', 'heads', 'tips'):
-            if refs_style == 'all':
+        if refs_style('heads') or refs_style('tips'):
+            if refs_style('heads') and refs_style('tips'):
                 self._head_template = 'refs/heads/branches/{}/{}'
                 self._tip_template = 'refs/heads/branches/{}/tip'
-            elif refs_style == 'heads':
+            elif refs_style('heads') and refs_style('bookmarks'):
+                self._head_template = 'refs/heads/branches/{}/{}'
+            elif refs_style('heads'):
                 self._head_template = 'refs/heads/{}/{}'
-            elif refs_style == 'tips':
+            elif refs_style('tips') and refs_style('bookmarks'):
+                self._tip_template = 'refs/heads/branches/{}'
+            elif refs_style('tips'):
                 self._tip_template = 'refs/heads/{}'
 
             for branch in sorted(branchmap.names()):
                 branch_tip = branchmap.tip(branch)
-                if refs_style != 'tips':
+                if refs_style('heads'):
                     for head in sorted(branchmap.heads(branch)):
-                        if head == branch_tip and refs_style == 'all':
+                        if head == branch_tip and refs_style('tips'):
                             continue
                         refs[self._head_template.format(branch, head)] = head
-                if branch_tip and refs_style != 'heads':
+                if branch_tip and refs_style('tips'):
                     refs[self._tip_template.format(branch)] = branch_tip
 
-        if refs_style in ('all', 'bookmarks'):
-            if refs_style == 'all':
+        if refs_style('bookmarks'):
+            if refs_style('heads') or refs_style('tips'):
                 self._bookmark_template = 'refs/heads/bookmarks/{}'
             else:
                 self._bookmark_template = 'refs/heads/{}'
@@ -328,11 +323,11 @@ class GitRemoteHelper(BaseRemoteHelper):
             refs['hg/revs/%s' % f] = f
 
         head_ref = None
-        if refs_style in ('all', 'bookmarks') and '@' in bookmarks:
+        if refs_style('bookmarks') and '@' in bookmarks:
             head_ref = self._bookmark_template.format('@')
-        elif refs_style in ('all', 'tips'):
+        elif refs_style('tips'):
             head_ref = self._tip_template.format('default')
-        elif refs_style == 'heads':
+        elif refs_style('heads'):
             head_ref = self._head_template.format(
                 'default', branchmap.tip('default'))
 
@@ -409,7 +404,7 @@ class GitRemoteHelper(BaseRemoteHelper):
         self._helper.write('done\n')
         self._helper.flush()
 
-        if self._remote.name and self._refs_style in ('all', 'heads'):
+        if self._remote.name and self._refs_style('heads'):
             if Git.config('fetch.prune', self._remote.name) != 'true':
                 prune = 'remote.%s.prune' % self._remote.name
                 sys.stderr.write(

--- a/cinnabar/util.py
+++ b/cinnabar/util.py
@@ -98,16 +98,21 @@ def init_logging():
 
 
 class ConfigSetFunc(object):
-    def __init__(self, key, values, extra_values=()):
+    def __init__(self, key, values, extra_values=(), default='', remote=None):
         self._config = None
         self._key = key
         self._values = values
         self._extra_values = extra_values
+        self._default = default
+        self._remote = remote
 
     def __call__(self, name):
         if self._config is None:
             from .git import Git
-            config = Git.config(self._key) or ''
+            if self._remote:
+                config = Git.config(self._key, self._remote) or self._default
+            else:
+                config = Git.config(self._key) or self._default
             if config:
                 config = config.split(',')
             self._config = set()

--- a/tests/ls-remote.t
+++ b/tests/ls-remote.t
@@ -44,6 +44,23 @@
 
   $ git -c cinnabar.refs=bookmarks ls-remote hg::$REPO
 
+  $ git -c cinnabar.refs=bookmarks,tips ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  0000000000000000000000000000000000000000	refs/heads/branches/default
+  0000000000000000000000000000000000000000	refs/heads/branches/foo
+
+  $ git -c cinnabar.refs=bookmarks,heads ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  0000000000000000000000000000000000000000	refs/heads/branches/default/636e60525868096cbdc961870493510558f41d2f
+  0000000000000000000000000000000000000000	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  0000000000000000000000000000000000000000	refs/heads/branches/foo/312a5a9c675e3ce302a33bd4605205a6be36d561
+
+  $ git -c cinnabar.refs=bookmarks,heads,tips ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  0000000000000000000000000000000000000000	refs/heads/branches/default/636e60525868096cbdc961870493510558f41d2f
+  0000000000000000000000000000000000000000	refs/heads/branches/default/tip
+  0000000000000000000000000000000000000000	refs/heads/branches/foo/tip
+
   $ git clone -q hg::$REPO repo-git
   It is recommended that you set "remote.origin.prune" or "fetch.prune" to "true".
     git config remote.origin.prune true
@@ -68,6 +85,23 @@
   23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/foo/312a5a9c675e3ce302a33bd4605205a6be36d561
 
   $ git -c cinnabar.refs=bookmarks -C repo-git ls-remote hg::$REPO
+
+  $ git -c cinnabar.refs=bookmarks,tips -C repo-git ls-remote hg::$REPO
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo
+
+  $ git -c cinnabar.refs=bookmarks,heads -C repo-git ls-remote hg::$REPO
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/branches/default/636e60525868096cbdc961870493510558f41d2f
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/312a5a9c675e3ce302a33bd4605205a6be36d561
+
+  $ git -c cinnabar.refs=bookmarks,heads,tips -C repo-git ls-remote hg::$REPO
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/branches/default/636e60525868096cbdc961870493510558f41d2f
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/tip
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/tip
 
   $ cd repo
   $ hg bookmark bar -r 1
@@ -100,6 +134,32 @@
   0000000000000000000000000000000000000000	refs/heads/fooz
   0000000000000000000000000000000000000000	refs/heads/qux
 
+  $ git -c cinnabar.refs=bookmarks,tips ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/bar
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/fooz
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/qux
+  0000000000000000000000000000000000000000	refs/heads/branches/default
+  0000000000000000000000000000000000000000	refs/heads/branches/foo
+
+  $ git -c cinnabar.refs=bookmarks,heads ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/bar
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/fooz
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/qux
+  0000000000000000000000000000000000000000	refs/heads/branches/default/636e60525868096cbdc961870493510558f41d2f
+  0000000000000000000000000000000000000000	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  0000000000000000000000000000000000000000	refs/heads/branches/foo/312a5a9c675e3ce302a33bd4605205a6be36d561
+
+  $ git -c cinnabar.refs=bookmarks,heads,tips ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/bar
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/fooz
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/qux
+  0000000000000000000000000000000000000000	refs/heads/branches/default/636e60525868096cbdc961870493510558f41d2f
+  0000000000000000000000000000000000000000	refs/heads/branches/default/tip
+  0000000000000000000000000000000000000000	refs/heads/branches/foo/tip
+
   $ git -C repo-git ls-remote hg::$REPO
   5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
   d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/bookmarks/bar
@@ -124,6 +184,32 @@
   d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/bar
   23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/fooz
   7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/qux
+
+  $ git -c cinnabar.refs=bookmarks,tips -C repo-git ls-remote hg::$REPO
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo
+
+  $ git -c cinnabar.refs=bookmarks,heads -C repo-git ls-remote hg::$REPO
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/branches/default/636e60525868096cbdc961870493510558f41d2f
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/312a5a9c675e3ce302a33bd4605205a6be36d561
+
+  $ git -c cinnabar.refs=bookmarks,heads,tips -C repo-git ls-remote hg::$REPO
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/branches/default/636e60525868096cbdc961870493510558f41d2f
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/tip
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/tip
 
   $ cd repo
   $ hg update -r 1 > /dev/null
@@ -155,6 +241,32 @@
   23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/fooz
   7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/qux
 
+  $ git -c cinnabar.refs=bookmarks,tips -C repo-git ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  0000000000000000000000000000000000000000	refs/heads/branches/default
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo
+
+  $ git -c cinnabar.refs=bookmarks,heads -C repo-git ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  0000000000000000000000000000000000000000	refs/heads/branches/default/8bb4ccecc30b8db9a6f524f40be0d4c2dbc78a07
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/312a5a9c675e3ce302a33bd4605205a6be36d561
+
+  $ git -c cinnabar.refs=bookmarks,heads,tips -C repo-git ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  d04f6df4abe2870ceb759263ee6aaa9241c4f93c	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  0000000000000000000000000000000000000000	refs/heads/branches/default/tip
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/tip
+
   $ hg -R repo bookmark bar -f -r 7 > /dev/null
 
   $ git -C repo-git ls-remote hg::$REPO
@@ -181,6 +293,32 @@
   0000000000000000000000000000000000000000	refs/heads/bar
   23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/fooz
   7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/qux
+
+  $ git -c cinnabar.refs=bookmarks,tips -C repo-git ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  0000000000000000000000000000000000000000	refs/heads/branches/default
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo
+
+  $ git -c cinnabar.refs=bookmarks,heads -C repo-git ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  0000000000000000000000000000000000000000	refs/heads/branches/default/8bb4ccecc30b8db9a6f524f40be0d4c2dbc78a07
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/312a5a9c675e3ce302a33bd4605205a6be36d561
+
+  $ git -c cinnabar.refs=bookmarks,heads,tips -C repo-git ls-remote hg::$REPO
+  0000000000000000000000000000000000000000	HEAD
+  0000000000000000000000000000000000000000	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  0000000000000000000000000000000000000000	refs/heads/branches/default/tip
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/tip
 
   $ git -c fetch.prune=true -C repo-git remote update
   Fetching origin
@@ -217,6 +355,32 @@
   23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/fooz
   7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/qux
 
+  $ git -c cinnabar.refs=bookmarks,tips -C repo-git ls-remote hg::$REPO
+  445bd26f53d0d2b946eda781eae0e11cf665493d	HEAD
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/branches/default
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo
+
+  $ git -c cinnabar.refs=bookmarks,heads -C repo-git ls-remote hg::$REPO
+  445bd26f53d0d2b946eda781eae0e11cf665493d	HEAD
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/branches/default/8bb4ccecc30b8db9a6f524f40be0d4c2dbc78a07
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/312a5a9c675e3ce302a33bd4605205a6be36d561
+
+  $ git -c cinnabar.refs=bookmarks,heads,tips -C repo-git ls-remote hg::$REPO
+  445bd26f53d0d2b946eda781eae0e11cf665493d	HEAD
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/branches/default/tip
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/tip
+
   $ hg -R repo bookmark @ -r 3
 
   $ git -C repo-git ls-remote hg::$REPO
@@ -246,3 +410,32 @@
   445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/bar
   23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/fooz
   7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/qux
+
+  $ git -c cinnabar.refs=bookmarks,tips -C repo-git ls-remote hg::$REPO
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/bookmarks/@
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/branches/default
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo
+
+  $ git -c cinnabar.refs=bookmarks,heads -C repo-git ls-remote hg::$REPO
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/bookmarks/@
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/branches/default/8bb4ccecc30b8db9a6f524f40be0d4c2dbc78a07
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/312a5a9c675e3ce302a33bd4605205a6be36d561
+
+  $ git -c cinnabar.refs=bookmarks,heads,tips -C repo-git ls-remote hg::$REPO
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	HEAD
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/bookmarks/@
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/bookmarks/bar
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/bookmarks/fooz
+  7688446e0a5d5b6108443632be74c9bca72d31b1	refs/heads/bookmarks/qux
+  5c5b259d3c128f3d7b50ce3bd5c9eaafd8d17611	refs/heads/branches/default/7937e1a594596ae25c637d317503d775767671b5
+  445bd26f53d0d2b946eda781eae0e11cf665493d	refs/heads/branches/default/tip
+  23bcc26b9fea7e37426260465bed35eac54af5e1	refs/heads/branches/foo/tip


### PR DESCRIPTION
This is intended to fix #220 by allowing the user to configure `cinnabar.refs` with a comma separated list of ref style keywords.