### PR TITLE
Use os.environ inside Git.config on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 git-cinnabar-helper
+git-cinnabar-helper.exe
 *.patched.c
 *.pyc

--- a/cinnabar/git.py
+++ b/cinnabar/git.py
@@ -135,7 +135,12 @@ class Git(object):
         if name.startswith('cinnabar.'):
             var = ('GIT_%s' % name.replace('.', '_').upper()).encode('ascii')
             if sys.version_info[0] == 3:
-                value = os.environb.get(var)
+                if os.supports_bytes_environ:
+                    value = os.environb.get(var)
+                else:
+                    value = os.environ.get(var.decode('utf-8'))
+                    if isinstance(value, str):
+                        value = value.encode('utf-8')
             else:
                 value = os.environ.get(var)
             if value is None and remote:

--- a/cinnabar/helper.py
+++ b/cinnabar/helper.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import subprocess
+import sys
 from binascii import unhexlify
 from types import GeneratorType
 from io import BytesIO
@@ -111,8 +112,13 @@ class BaseHelper(object):
         if self._helper is False:
             helper_path = Git.config('cinnabar.helper')
             env = {
-                b'GIT_REPLACE_REF_BASE': b'refs/cinnabar/replace/',
+                'GIT_REPLACE_REF_BASE': 'refs/cinnabar/replace/',
             }
+            if sys.version_info[0] == 2:
+                encoded = {}
+                for (k, v) in env.iteritems():
+                    encoded[k.encode('utf-8')] = v.encode('utf-8')
+                env = encoded
             for k in os.environ:
                 if k.startswith('GIT_CINNABAR_'):
                     env[k] = os.environ[k]

--- a/cinnabar/hg/repo.py
+++ b/cinnabar/hg/repo.py
@@ -1087,7 +1087,7 @@ def get_ui():
     if not ssh:
         ssh = os.environ.get('GIT_SSH')
         if ssh:
-            ssh = procutil.shellquote(ssh)
+            ssh = procutil.shellquote(ssh.encode('utf-8'))
     if ssh:
         ui_.setconfig(b'ui', b'ssh', ssh)
     return ui_


### PR DESCRIPTION
Fixes #245

I was already writing a patch before reading your comment 👀

~~This is certainly larger than your patch but I think preferring unicode is more future-proof.~~

Modified to keep using bytes to follow https://github.com/glandium/git-cinnabar/pull/246#issuecomment-613672393