### PR TITLE
Fix helper version fallback.

### DIFF
--- a/cinnabar/cmd/util.py
+++ b/cinnabar/cmd/util.py
@@ -108,7 +108,7 @@ class Version(argparse.Action):
         except Exception:
             version = 'unknown'
 
-        sha1 = (helper_hash() or 'unknown').decode('ascii')
+        sha1 = (helper_hash() or b'unknown').decode('ascii')
         return version, sha1
 
     def __call__(self, parser, namespace, values, option_string=None):


### PR DESCRIPTION
Can't run `.decode` on a string.