### PR TITLE
Fix collections imports on Python 3.10.

### DIFF
--- a/cinnabar/githg.py
+++ b/cinnabar/githg.py
@@ -16,9 +16,12 @@ except ImportError:
     from urllib import unquote as unquote_to_bytes
 from collections import (
     OrderedDict,
-    Sequence,
     defaultdict,
 )
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 try:
     from urllib2 import URLError
 except ImportError:

--- a/cinnabar/util.py
+++ b/cinnabar/util.py
@@ -18,9 +18,12 @@ except ImportError:
     )
 from collections import (
     deque,
-    Iterable,
     OrderedDict,
 )
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from difflib import (
     Match,
     SequenceMatcher,


### PR DESCRIPTION
The abc classes were moved in 3.3, and 3.10 finally removes the deprecated aliases.