### PR TITLE
Add an extra day to the 7 day fsck reminder.

### DIFF
--- a/cinnabar/githg.py
+++ b/cinnabar/githg.py
@@ -1302,7 +1302,9 @@ class GitHgStore(object):
             if ref not in (b'refs/notes/cinnabar',):
                 Git.delete_ref(ref)
 
+        # Warn after 8 full days to allow weekly cron jobs to avoid resulting
+        # in spurious warnings.
         if self._metadata_sha1 and update_metadata and not refresh and \
-                interval_expired('fsck', 86400 * 7):
+                interval_expired('fsck', 86400 * 8):
             logging.warn('Have you run `git cinnabar fsck` recently?')
         GitHgHelper.close(rollback=False)


### PR DESCRIPTION
Currently the fsck reminder fires after 7 days, which means that weekly
cron jobs may potentially emit the warning if the fsck isn't run at
exactly the same moment each week.  Adding an extra day allows for
weekly cron jobs to run any time during their day of the week without
experiencing warnings.