### PR TITLE
Set the Content-Type header when adding tasks

### DIFF
--- a/CI/tasks.py
+++ b/CI/tasks.py
@@ -374,7 +374,7 @@ class Task(object):
         if 'TC_PROXY' not in os.environ:
             return
         url = 'http://taskcluster/api/queue/v1/task/{}'.format(self.id)
-        res = session.put(url, data=json.dumps(self.task))
+        res = session.put(url, json=self.task)
         try:
             res.raise_for_status()
         except Exception:


### PR DESCRIPTION
When submitting the task definition to the Taskcluster queue (via PUT), use the ``json`` parameter so that the task definition will be JSON-serialized and the ``Content-Type`` header will be set to ``application/json`` (See [More complicated POST requests](https://docs.python-requests.org/en/latest/user/quickstart/#more-complicated-post-requests)). Fixes #284.