### PR TITLE
Quote path to git-cinnabar when passing to python (fixes #288)

### DIFF
--- a/git-cinnabar
+++ b/git-cinnabar
@@ -17,7 +17,7 @@ case "$experiments" in
   fi
   ;;
 esac
-exec $PYTHON $0 "$@"
+exec $PYTHON "$0" "$@"
 exit 1
 '''
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -17,7 +17,7 @@ case "$experiments" in
   fi
   ;;
 esac
-exec $PYTHON $0 "$@"
+exec $PYTHON "$0" "$@"
 exit 1
 '''
 


### PR DESCRIPTION
To solve #288, the path to git-cinnabar should be quoted when passing to python,
to avoid passing the path as multiple parameter when it contains spaces.