### PR TITLE
Add `python` to the list of fallbacks if `python3` is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Setup:
 Python:
 -------
 
-git-cinnabar will use one of `python3`, `python2.7` or `python2`, whichever has
-mercurial libraries. If none of them does, it will use the first that can be
-found.
+git-cinnabar will use one of `python3`, `python`, `python2.7` or `python2`,
+whichever has mercurial libraries. If none of them does, it will use the first
+that can be found.
 
 You may force a specific python through the `GIT_CINNABAR_PYTHON` environment
 variable.

--- a/git-cinnabar
+++ b/git-cinnabar
@@ -2,13 +2,13 @@
 ''':'
 py="$GIT_CINNABAR_PYTHON"
 if test -z "$py"; then
-  for py in python3 python2.7 python2; do
+  for py in python3 python python2.7 python2; do
     "$py" -c "from mercurial import hg" >/dev/null 2>&1 && break
     py=
   done
 fi
 if test -z "$py"; then
-  for py in python3 python2.7 python2; do
+  for py in python3 python python2.7 python2; do
     command -v "$py" > /dev/null && break
     py=python3
   done

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -2,13 +2,13 @@
 ''':'
 py="$GIT_CINNABAR_PYTHON"
 if test -z "$py"; then
-  for py in python3 python2.7 python2; do
+  for py in python3 python python2.7 python2; do
     "$py" -c "from mercurial import hg" >/dev/null 2>&1 && break
     py=
   done
 fi
 if test -z "$py"; then
-  for py in python3 python2.7 python2; do
+  for py in python3 python python2.7 python2; do
     command -v "$py" > /dev/null && break
     py=python3
   done


### PR DESCRIPTION
I use Python provided by Visual Studio. It installs `python.exe` but not `python3.exe`.