### PR TITLE
Fix access to ssh remotes with absolute path

### DIFF
--- a/src/hg_connect_stdio.rs
+++ b/src/hg_connect_stdio.rs
@@ -186,7 +186,8 @@ pub fn get_stdio_connection(url: &Url, flags: c_int) -> Option<Box<dyn HgRepo>> 
         .port()
         .map(|port| CString::new(port.to_string()).unwrap());
     let path = if url.scheme() == "ssh" {
-        percent_decode_str(url.path().trim_start_matches('/')).collect_vec()
+        let path = url.path();
+        percent_decode_str(path.strip_prefix('/').unwrap_or(path)).collect_vec()
     } else {
         let path = url.to_file_path().unwrap();
         if path.metadata().map(|m| m.is_file()).unwrap_or(false) {


### PR DESCRIPTION
Mercurial only strips a single leading '/' from the path of an ssh remote, and preserves the rest.
`git-cinnabar` strips all the leading slashes, essentially corrupting the absolute paths in the remote URL and making it impossible to access such repositories.

Compare:
```
$ hg --debug clone ssh://localhost//home/alebastr/sources/repo | grep running
running ssh localhost 'hg -R /home/alebastr/sources/repo serve --stdio'

$ hg --debug clone ssh://localhost///home/alebastr/sources/repo | grep running
running ssh localhost 'hg -R //home/alebastr/sources/repo serve --stdio'

$ git clone hg::ssh://localhost//home/alebastr/sources/repo
Cloning into 'repo'...
remote: abort: repository home/alebastr/sources/repo not found
fatal: called `Result::unwrap()` on an `Err` value: ParseIntError { kind: Empty }
...
```
(note the leading slashes in the `hg -R` arguments)

Likely copied from https://github.com/glandium/git-cinnabar/commit/9e817b9c21b0949ef53bb4b88b59d0a33ff80860, as 0.5.x has the same bug. It was hidden because `mercurial.sshpeer` was the preferred connection method and resurfaced after Mercurial 6.4 changed the API and broke imports in `cinnabar/hg/repo.py`.