### PR TITLE
Specify "git-cinnabar" in self-update warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1561,7 +1561,7 @@ fn do_self_update(branch: Option<String>, exact: Option<CommitId>) -> Result<(),
         #[cfg(not(windows))]
         std::fs::remove_file(old_exe_path).ok();
     } else {
-        warn!(target: "root", "Did not find an update to install.");
+        warn!(target: "root", "Did not find a git-cinnabar update to install.");
     }
     Ok(())
 }


### PR DESCRIPTION
When working with `mozilla-central` via git, the git-cinnabar self-update ends up getting run as one part of `mach bootstrap`. In that context, the self-update warning ends up being shown as follows:
```
...
Would you like to run a few configuration steps to ensure Git is
optimally configured? (Yn):
WARNING Did not find an update to install.
...
```

As it's not otherwise obvious that this is about git-cinnabar, it's also not obvious that this warning can and should be dismissed. It would be more user-friendly to be a bit more precise in the text, as proposed here.