### PR TITLE
 Add MPL text to the published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/glandium/git-cinnabar"
 rust-version = "1.74.0"
 include = [
   "/src",
+  "/MPL-2.0",
   "/build.rs",
   "/.cargo",
   "/git-core/COPYING",


### PR DESCRIPTION
It's not required by the MPL itself, but our (Fedora Linux) packaging guidelines strongly encourage to include texts for all the licenses of the upstream source.