### PR TITLE
Make git push fail gracefully with nonzero exit status if upstream hg crashes or rejects push

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4845,25 +4845,28 @@ fn remote_helper_push(
                 let response = conn.unbundle(heads, file);
                 match response {
                     UnbundleResponse::Bundlev2(data) => {
-                        let mut bundle = BundleReader::new(data).unwrap();
-                        while let Some(part) = bundle.next_part().unwrap() {
-                            match part.part_type.as_bytes() {
-                                b"reply:changegroup" => {
-                                    // TODO: should check in-reply-to param.
-                                    let response = part.get_param("return").unwrap();
-                                    result = u32::from_str(response).ok();
-                                }
-                                b"error:abort" => {
-                                    let mut message =
-                                        part.get_param("message").unwrap().to_string();
-                                    if let Some(hint) = part.get_param("hint") {
-                                        message.push_str("\n\n");
-                                        message.push_str(hint);
+                        if let Ok(mut bundle) = BundleReader::new(data) {
+                            while let Ok(Some(part)) = bundle.next_part() {
+                                match part.part_type.as_bytes() {
+                                    b"reply:changegroup" => {
+                                        // TODO: should check in-reply-to param.
+                                        let response = part.get_param("return").unwrap();
+                                        result = u32::from_str(response).ok();
                                     }
-                                    error!(target: "root", "{}", message);
+                                    b"error:abort" => {
+                                        let mut message =
+                                            part.get_param("message").unwrap().to_string();
+                                        if let Some(hint) = part.get_param("hint") {
+                                            message.push_str("\n\n");
+                                            message.push_str(hint);
+                                        }
+                                        error!(target: "root", "{}", message);
+                                    }
+                                    _ => {}
                                 }
-                                _ => {}
                             }
+                        } else {
+                            pushed = ChangesetHeads::new();
                         }
                     }
                     UnbundleResponse::Raw(response) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4861,6 +4861,7 @@ fn remote_helper_push(
                                             message.push_str(hint);
                                         }
                                         error!(target: "root", "{}", message);
+                                        pushed = ChangesetHeads::new();
                                     }
                                     _ => {}
                                 }

--- a/tests/push.t
+++ b/tests/push.t
@@ -543,8 +543,6 @@ Grab the divergent commit in git:
 
 Verify that pushes to the divergent hg clone are rejected by a
 reject_new_heads hook:
-XXX This should fail with nonzero exit status and not update remote refs:
-https://github.com/glandium/git-cinnabar/issues/341
 
   $ cat > $REPO/.hg/hgrc <<EOF
   > [hooks]
@@ -560,11 +558,13 @@ https://github.com/glandium/git-cinnabar/issues/341
   \r (no-eol) (esc)
   ERROR Changes on branch 'default' resulted in multiple heads
   To hg::.*/push.t/repo (re)
-   + 687e015...846552c 846552c6f25c1b46e784f59d8249fb31afac2996 -> branches/default/tip (forced update)
+   ! [remote rejected] 846552c6f25c1b46e784f59d8249fb31afac2996 -> branches/default/tip (nothing changed on remote)
+  error: failed to push some refs to 'hg::.*/push.t/repo' (re)
+  [1]
   $ rm $REPO/.hg/hgrc
   $ git -C abc-git log --graph --remotes --oneline --no-abbrev-commit
-  * 846552c6f25c1b46e784f59d8249fb31afac2996 x
-  * bc90f2819ad12e294b313097b8763d26ca0c08ae b
+  * 687e015f9f646bb19797d991f2f53087297fbe14 c
+  * d04f6df4abe2870ceb759263ee6aaa9241c4f93c b
   * 8b86a58578d5270969543e287634e3a2f122a338 a
   $ hg -R $REPO log -G --template '{node} {branch} {desc}'
   o  c70941aaa15aa6e5feae28164438f13dc3cd7b8e default c
@@ -573,14 +573,6 @@ https://github.com/glandium/git-cinnabar/issues/341
   |
   o  f92470d7f6966a39dfbced6a525fe81ebf5c37b9 default a
   
-
-XXX Undo the changes to abc-git's view of the remote while the rejected
-push is incorrectly interpreted to have been applied:
-
-  $ git -c fetch.prune=true -C abc-git remote update origin
-  Fetching origin
-  From hg::.*/push.t/repo (re)
-   + 846552c...687e015 branches/default/tip -> origin/branches/default/tip  (forced update)
 
 Verify that pushes to the divergent clone are rejected by a broken
 hook:

--- a/tests/push.t
+++ b/tests/push.t
@@ -516,3 +516,103 @@ different than without the feature enabled.
   * 687e015f9f646bb19797d991f2f53087297fbe14 c
   * d04f6df4abe2870ceb759263ee6aaa9241c4f93c b
   * 8b86a58578d5270969543e287634e3a2f122a338 a
+
+Create a new commit in a divergent Mercurial clone.
+
+  $ ABX=$(pwd)/abx
+  $ hg clone -q -u 636e60525868096cbdc961870493510558f41d2f abc abx
+  $ cd abx
+  $ create x
+  $ cd ..
+  $ hg -R $ABX log -G --template '{node} {branch} {desc}'
+  @  2b10b3a49ff6e308c904c2c626d7e449480b6403 default x
+  |
+  | o  bd623dea939349b06a47d5dce064255e5f1d9ec1 default c
+  |/
+  o  636e60525868096cbdc961870493510558f41d2f default b
+  |
+  o  f92470d7f6966a39dfbced6a525fe81ebf5c37b9 default a
+  
+Grab the divergent commit in git:
+
+  $ git -C abc-git -c fetch.prune=true fetch -q hg::$ABX
+  $ git -C abc-git log --graph --oneline --no-abbrev-commit FETCH_HEAD
+  * 846552c6f25c1b46e784f59d8249fb31afac2996 x
+  * bc90f2819ad12e294b313097b8763d26ca0c08ae b
+  * 8b86a58578d5270969543e287634e3a2f122a338 a
+
+Verify that pushes to the divergent hg clone are rejected by a
+reject_new_heads hook:
+XXX This should fail with nonzero exit status and not update remote refs:
+https://github.com/glandium/git-cinnabar/issues/341
+
+  $ cat > $REPO/.hg/hgrc <<EOF
+  > [hooks]
+  > pretxnclose.reject_new_heads = python:hgext.hooklib.reject_new_heads.hook
+  > EOF
+  $ git -C abc-git push -f origin 846552c6f25c1b46e784f59d8249fb31afac2996:branches/default/tip
+  remote: adding changesets
+  remote: adding manifests
+  remote: adding file changes
+  remote: error: pretxnclose.reject_new_heads hook failed: Changes on branch 'default' resulted in multiple heads
+  remote: transaction abort!
+  remote: rollback completed
+  \r (no-eol) (esc)
+  ERROR Changes on branch 'default' resulted in multiple heads
+  To hg::.*/push.t/repo (re)
+   + 687e015...846552c 846552c6f25c1b46e784f59d8249fb31afac2996 -> branches/default/tip (forced update)
+  $ rm $REPO/.hg/hgrc
+  $ git -C abc-git log --graph --remotes --oneline --no-abbrev-commit
+  * 846552c6f25c1b46e784f59d8249fb31afac2996 x
+  * bc90f2819ad12e294b313097b8763d26ca0c08ae b
+  * 8b86a58578d5270969543e287634e3a2f122a338 a
+  $ hg -R $REPO log -G --template '{node} {branch} {desc}'
+  o  c70941aaa15aa6e5feae28164438f13dc3cd7b8e default c
+  |
+  o  29872b591f8d41c613bbfad38722824ab0457f17 default b
+  |
+  o  f92470d7f6966a39dfbced6a525fe81ebf5c37b9 default a
+  
+
+XXX Undo the changes to abc-git's view of the remote while the rejected
+push is incorrectly interpreted to have been applied:
+
+  $ git -c fetch.prune=true -C abc-git remote update origin
+  Fetching origin
+  From hg::.*/push.t/repo (re)
+   + 846552c...687e015 branches/default/tip -> origin/branches/default/tip  (forced update)
+
+Verify that pushes to the divergent clone are rejected by a broken
+hook:
+XXX This should not crash git-cinnabar:
+https://github.com/glandium/git-cinnabar/issues/338
+
+  $ cat > $REPO/.hg/hgrc <<EOF
+  > [hooks]
+  > pretxnclose = python:/nonexistent:fail
+  > EOF
+  $ git -C abc-git push -f origin 846552c6f25c1b46e784f59d8249fb31afac2996:branches/default/tip
+  remote: adding changesets
+  remote: adding manifests
+  remote: adding file changes
+  remote: loading pretxnclose hook failed:
+  remote: transaction abort!
+  remote: rollback completed
+  remote: abort: No such file or directory: '/nonexistent'
+  fatal: called `Result::unwrap()` on an `Err` value: Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }
+  Run the command again with `git -c cinnabar.check=traceback <command>` to see the full traceback.
+  error: git-remote-hg died of signal 6
+  error: failed to push some refs to 'hg::.*/push.t/repo' (re)
+  [1]
+  $ rm $REPO/.hg/hgrc
+  $ git -C abc-git log --graph --remotes --oneline --no-abbrev-commit
+  * 687e015f9f646bb19797d991f2f53087297fbe14 c
+  * d04f6df4abe2870ceb759263ee6aaa9241c4f93c b
+  * 8b86a58578d5270969543e287634e3a2f122a338 a
+  $ hg -R $REPO log -G --template '{node} {branch} {desc}'
+  o  c70941aaa15aa6e5feae28164438f13dc3cd7b8e default c
+  |
+  o  29872b591f8d41c613bbfad38722824ab0457f17 default b
+  |
+  o  f92470d7f6966a39dfbced6a525fe81ebf5c37b9 default a
+  

--- a/tests/push.t
+++ b/tests/push.t
@@ -584,8 +584,6 @@ push is incorrectly interpreted to have been applied:
 
 Verify that pushes to the divergent clone are rejected by a broken
 hook:
-XXX This should not crash git-cinnabar:
-https://github.com/glandium/git-cinnabar/issues/338
 
   $ cat > $REPO/.hg/hgrc <<EOF
   > [hooks]
@@ -599,9 +597,8 @@ https://github.com/glandium/git-cinnabar/issues/338
   remote: transaction abort!
   remote: rollback completed
   remote: abort: No such file or directory: '/nonexistent'
-  fatal: called `Result::unwrap()` on an `Err` value: Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }
-  Run the command again with `git -c cinnabar.check=traceback <command>` to see the full traceback.
-  error: git-remote-hg died of signal 6
+  To hg::.*/push.t/repo (re)
+   ! [remote rejected] 846552c6f25c1b46e784f59d8249fb31afac2996 -> branches/default/tip (nothing changed on remote)
   error: failed to push some refs to 'hg::.*/push.t/repo' (re)
   [1]
   $ rm $REPO/.hg/hgrc


### PR DESCRIPTION
Intended to fix the following three issues:

- https://github.com/glandium/git-cinnabar/issues/341
- https://github.com/glandium/git-cinnabar/issues/338
- ~https://github.com/glandium/git-cinnabar/issues/339~ (moved to https://github.com/glandium/git-cinnabar/pull/343)

Not 100% sure about the logic here in remote_helper_push, but it seems to produce the desired effect in the test cases.  In particular, the mechanism for propagating an error through (resetting `pushed` to empty) seems questionable, and it's not immediately clear to me what to do about multi-part bundlev2 responses.