### PR TITLE
tests/push-refs.t: Set committer name when making a tag.

### DIFF
--- a/tests/push-refs.t
+++ b/tests/push-refs.t
@@ -375,7 +375,7 @@ Removing heads or branches is not supported.
 
 Pushing/deleting tags is not supported.
 
-  $ git -C repo-git -c user.email=foo@bar tag -m 'Tagged' the-tag
+  $ git -C repo-git -c user.name=foo -c user.email=foo@bar tag -m 'Tagged' the-tag
   $ git -C repo-git push origin --tags
   To hg::.*/push-refs.t/repo-from-git (re)
    ! [remote rejected] the-tag -> the-tag (Pushing tags is unsupported)


### PR DESCRIPTION
Otherwise git will grab it from ~/.gitconfig, or fail if it's not there, both of which are wrong for reproducible tests.

fix https://github.com/glandium/git-cinnabar/issues/339