### PR TITLE
Add ubuntu-24.04-arm to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         toolchain: [1.84.0]
         include:
           - os: windows-latest

--- a/src/hg_connect_http.rs
+++ b/src/hg_connect_http.rs
@@ -294,7 +294,7 @@ unsafe extern "C" fn trace_log_callback(
         CURLINFO_HEADER_OUT => logging::Direction::Send,
         _ => return 0,
     };
-    let data = std::slice::from_raw_parts(data as *const u8, size);
+    let data = std::slice::from_raw_parts(data as *const _, size);
     for line in data.lines() {
         trace!(target: target, "{} {}", direction, line.as_bstr());
     }
@@ -647,7 +647,7 @@ unsafe extern "C" fn http_request_execute(
 ) -> usize {
     let data = (data as *mut HttpThreadData).as_mut().unwrap();
     http_send_info(data);
-    let buf = std::slice::from_raw_parts(ptr as *const u8, size.checked_mul(nmemb).unwrap());
+    let buf = std::slice::from_raw_parts(ptr as *const _, size.checked_mul(nmemb).unwrap());
     if let Some(logger) = &mut data.logger {
         logger.write_all(buf).unwrap();
     }
@@ -863,7 +863,7 @@ unsafe extern "C" fn read_from_read<R: Read>(
     data: *const c_void,
 ) -> usize {
     let read = (data as *mut R).as_mut().unwrap();
-    let buf = std::slice::from_raw_parts_mut(ptr as *mut u8, size.checked_mul(nmemb).unwrap());
+    let buf = std::slice::from_raw_parts_mut(ptr as *mut _, size.checked_mul(nmemb).unwrap());
     read.read(buf).unwrap()
 }
 

--- a/src/libcinnabar.rs
+++ b/src/libcinnabar.rs
@@ -27,7 +27,7 @@ pub struct strslice<'a> {
 
 impl strslice<'_> {
     pub fn as_bytes(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.buf as *const u8, self.len) }
+        unsafe { std::slice::from_raw_parts(self.buf as *const _, self.len) }
     }
 }
 

--- a/src/libgit.rs
+++ b/src/libgit.rs
@@ -316,7 +316,7 @@ impl<T: ?Sized> Drop for FfiBox<T> {
 
 impl From<strbuf> for FfiBox<[u8]> {
     fn from(value: strbuf) -> Self {
-        let ptr = value.buf as *mut u8;
+        let ptr = value.buf as *mut _;
         let len = value.len;
         mem::forget(value);
         unsafe { FfiBox::from_raw_parts(ptr, len) }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1477,7 +1477,7 @@ pub fn store_git_tree(tree_buf: &[u8], reference: Option<TreeId>) -> TreeId {
                 let mut reftree_buf = ptr::null_mut();
                 let mut len = 0;
                 unpack_object_entry(oe, &mut reftree_buf, &mut len);
-                ref_tree = Some(FfiBox::from_raw_parts(reftree_buf as *mut u8, len as usize));
+                ref_tree = Some(FfiBox::from_raw_parts(reftree_buf as *mut _, len as usize));
             }
         }
         let mut result = object_id::default();


### PR DESCRIPTION
I wonder `c_uchar` can be used instead, but that's a bigger change that is not necessary here.

This also adds `#[allow(clippy::unnecessary_cast)]` on some lines where `*mut c_char` is being casted to `*mut u8`. (It seems there were multiple attempts from clippy side to make this less strict, but it still happens.)