### PR TITLE
Add support for tracking topics as remote refs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ combined in a comma-separated list:
   `refs/heads/$branch/$head`, where `$branch` is the mercurial branch name
   and `$head` is the full changeset sha1 of that head.
 
+- `topics`: in this mode, the mercurial repository's topics are exposed
+  as `refs/heads/topics/$branch/$topic`, where `$branch` is the
+  mercurial branch name and `$topic` is the topic name on that branch.
+
 When these values are used in combinations, the branch mappings are varied
 accordingly to make the type of each remote ref explicit and to avoid name
 collisions.
@@ -125,21 +129,29 @@ collisions.
 - When combining `bookmarks` and `heads`, bookmarks are exposed as
   `refs/heads/bookmarks/$bookmark` and branch heads are exposed as
   `refs/heads/branches/$branch/$head` (where `$head` is the full changeset
-  sha1 of the head).
+  sha1 of the head). Similarly, when combining `topics` and `heads`,
+  topics are exposed as `refs/heads/topics/$branch/$topic/$head` and
+  branch heads are exposed as `refs/heads/branches/$branch/$head`.
 
 - When combining `bookmarks` and `tips`, bookmarks are exposed as
   `refs/heads/bookmarks/$bookmark` and branch tips are exposed as
   `refs/heads/branches/$branch`. Any other heads of the same branch are not
-  exposed.
+  exposed. Similarly, when combining `topics` and `tips`, topic tips are
+  exposed as `refs/heads/topics/$branch/$topic` and branch tips are exposed
+  as `refs/heads/branches/$branch`. Any other heads of the same topic are
+  not exposed.
 
 - When combining all of `bookmarks`, `heads`, and `tips`, bookmarks are
   exposed as `refs/heads/bookmarks/$bookmark`, branch heads are exposed as
   `refs/heads/branches/$branch/$head` (where `$head` is the full changeset
   sha1 of the head), except for the branch tips, which are exposed as
-  `refs/heads/branches/$branch/tip`.
+  `refs/heads/branches/$branch/tip`.  Similarly, if `topics` is added to
+  the mix, topic heads are also exposed as
+  `refs/heads/topics/$branch/$topic/$head`, except for the topic tip, which
+  is exposed as refs/heads/topics/$branch/$topic/tip.
 
-The shorthand `all` (also the default), is the combination of `bookmarks`,
-`heads`, and `tips`.
+The shorthand `all` is the combination of `bookmarks`, `heads`, `tips`,
+and `topics`. The default is `bookmarks`, `heads, and `tips`.
 
 The refs style can also be configured per remote with the
 `remote.$remote.cinnabar-refs` configuration. It is also possible to use

--- a/src/store.rs
+++ b/src/store.rs
@@ -1864,6 +1864,7 @@ pub fn create_changeset(
     manifest_id: HgManifestId,
     files: Option<Box<[u8]>>,
     branch: Option<&BStr>,
+    topic: Option<&BStr>,
 ) -> (HgChangesetId, GitChangesetMetadataId) {
     let mut cs_metadata = GitChangesetMetadata {
         changeset_id: HgChangesetId::NULL,
@@ -1889,6 +1890,10 @@ pub fn create_changeset(
     if let Some(branch) = &branch {
         let extra = extra.get_or_insert_with(ChangesetExtra::new);
         extra.set(b"branch", branch);
+    }
+    if let Some(topic) = &topic {
+        let extra = extra.get_or_insert_with(ChangesetExtra::new);
+        extra.set(b"topic", topic);
     }
     let git_commit_extra = experiment(Experiments::GIT_COMMIT).then(|| commit_id.to_string());
     if let Some(git_commit_extra) = &git_commit_extra {

--- a/tests/topic.t
+++ b/tests/topic.t
@@ -1,0 +1,104 @@
+#!/usr/bin/env cram
+
+  $ PATH=$TESTDIR/..:$PATH
+
+  $ cat >hgrc <<EOF
+  > [extensions]
+  > topic = 
+  > [phases]
+  > publish = false
+  > EOF
+  $ export HGRCPATH=$(pwd)/hgrc
+
+  $ n=0
+  $ create() {
+  >   echo $1 > $1
+  >   hg add $1
+  >   hg commit -q -m $1 -u nobody -d "$n 0"
+  >   n=$(expr $n + 1)
+  > }
+  $ hg init abc
+  $ ABC=$(pwd)/abc
+  $ cd abc
+  $ for f in a b c; do create $f; done
+  $ hg -q topic test-topic
+  $ create d
+  $ cd ..
+  $ hg -R abc log -G
+  @  changeset:   3:c8e7b9c226ba
+  |  tag:         tip
+  |  topic:       test-topic
+  |  user:        nobody
+  |  date:        Thu Jan 01 00:00:03 1970 +0000
+  |  summary:     d
+  |
+  o  changeset:   2:bd623dea9393
+  |  user:        nobody
+  |  date:        Thu Jan 01 00:00:02 1970 +0000
+  |  summary:     c
+  |
+  o  changeset:   1:636e60525868
+  |  user:        nobody
+  |  date:        Thu Jan 01 00:00:01 1970 +0000
+  |  summary:     b
+  |
+  o  changeset:   0:f92470d7f696
+     user:        nobody
+     date:        Thu Jan 01 00:00:00 1970 +0000
+     summary:     a
+  
+  $ git -c fetch.prune=true -c cinnabar.refs=topics clone -n -q hg::$ABC abc-git
+  $ git -C abc-git -c cinnabar.refs=topics ls-remote hg::$ABC
+  687e015f9f646bb19797d991f2f53087297fbe14	HEAD
+  687e015f9f646bb19797d991f2f53087297fbe14	refs/heads/branches/default
+  f0a1cba4d5a6919f6ba44b775278734fb5e30f78	refs/heads/topics/default/test-topic
+  $ git -C abc-git for-each-ref refs/remotes/origin
+  687e015f9f646bb19797d991f2f53087297fbe14 commit	refs/remotes/origin/HEAD
+  687e015f9f646bb19797d991f2f53087297fbe14 commit	refs/remotes/origin/branches/default
+  f0a1cba4d5a6919f6ba44b775278734fb5e30f78 commit	refs/remotes/origin/topics/default/test-topic
+  $ git -C abc-git switch -q --guess topics/default/test-topic
+  $ cd abc-git
+  $ git branch -vvv
+    branches/default          687e015 [origin/branches/default] c
+  * topics/default/test-topic f0a1cba [origin/topics/default/test-topic] d
+  $ echo e > e
+  $ git add e
+  $ GIT_COMMITTER_DATE="1970-01-01 0:0:0$n" git -c user.name=Nobody -c user.email=nobody@nowhere commit -q -m e --date "1970-01-01 0:0:$n"
+  $ n=$(expr $n + 1)
+  $ cd ..
+  $ git -C abc-git -c cinnabar.refs=topics -c cinnabar.experiments=branch push origin
+  remote: adding changesets
+  remote: adding manifests
+  remote: adding file changes
+  remote: added 1 changesets with 1 changes to 1 files
+  To hg::.*/topic.t/abc (re)
+     f0a1cba..dc5dded  topics/default/test-topic -> topics/default/test-topic
+  $ hg -R abc log -G
+  o  changeset:   4:e18393ddcc87
+  |  tag:         tip
+  |  topic:       test-topic
+  |  user:        Nobody <nobody@nowhere>
+  |  date:        Thu Jan 01 00:00:04 1970 +0000
+  |  summary:     e
+  |
+  @  changeset:   3:c8e7b9c226ba
+  |  topic:       test-topic
+  |  user:        nobody
+  |  date:        Thu Jan 01 00:00:03 1970 +0000
+  |  summary:     d
+  |
+  o  changeset:   2:bd623dea9393
+  |  user:        nobody
+  |  date:        Thu Jan 01 00:00:02 1970 +0000
+  |  summary:     c
+  |
+  o  changeset:   1:636e60525868
+  |  user:        nobody
+  |  date:        Thu Jan 01 00:00:01 1970 +0000
+  |  summary:     b
+  |
+  o  changeset:   0:f92470d7f696
+     user:        nobody
+     date:        Thu Jan 01 00:00:00 1970 +0000
+     summary:     a
+  


### PR DESCRIPTION
NOTE: New tests will require the [hg-evolve extension](https://foss.heptapod.net/mercurial/evolve) to be installed and available.  This change does not yet update the CI logic to make that happen, so I expect the new tests will fail until it is updated.

Like Mercurial branches, Mercurial topics are labels in the metadata of a changeset.  While branches are meant for long-term history, topics are meant for short-term work-in-progress, like git feature branches for github pull requests.  Once a topic is made public, the topic name is hidden by default.  Each topic is associated with a branch; the fully-qualified name is written `<branch>//<topic>` when the branch is not implied.

This adds a new option 'topics' to the cinnabar.refs knob to expose topic T of branch B as any of

- `refs/heads/topics/<B>/<T>`
- `refs/heads/topics/<B>/<T>/tip`
- `refs/heads/topics/<B>/<T>/<SHA1>`

depending on whether 'tips' or 'heads' is included too.  When cinnabar.refs has 'topics' included, branch heads and bookmarks are also exposed under 'refs/heads/branches/...' and
'refs/heads/bookmarks/...' too like with certain other combinations of options.

Topics are detected using essentially the same method by which branches are detected.  Once a topic is published, the corresponding refs/heads/topics/* refs will vanish.

When the remote hg server advertises support with the 'topics-namespaces' extension, use the 'branchmaptns' rather than 'branchmap' cmd to query the remote heads so we can distinguish between topics and branches.

By default, cinnabar.refs does not have 'topics' included, so there is no change to the semantics.

fix https://github.com/glandium/git-cinnabar/issues/326